### PR TITLE
Duplicated route key removed in services-z1 Job

### DIFF
--- a/config/aws/cf-tiny.yml
+++ b/config/aws/cf-tiny.yml
@@ -233,8 +233,6 @@ jobs:
         port: 5155
         uris:
         - "hm9000.${cf-domain}"
-
-      routes:
       - name: doppler
         registration_interval: 20s
         port: 8081


### PR DESCRIPTION
There was a duplicate key in the manifest for cf-tiny, which would stop my AWS Bosh director from setting the deployment to the cf-tiny.yml manifest. I removed the duplicate `route` key and it worked just fine.
