### PR TITLE
Destroy bosh

### DIFF
--- a/bin/nbb
+++ b/bin/nbb
@@ -70,6 +70,13 @@ provision_vpc() {
       terraform apply -var-file terraform.tfvars
       ;;
     (destroy)
+      # Run bosh director
+      _bastionIP="$(tf_var bastion_ip)"
+      _keyPath="$(sed -e "s#^~#${HOME}#" < <(tf_var aws_key_path))"
+
+      _cmd="DEBUG=true \${HOME}/provision destroy"
+      ssh -t -i "${_keyPath}" centos@"${_bastionIP}" "${_cmd}"
+
       terraform plan -destroy -var-file terraform.tfvars -out terraform.tfplan
       terraform apply terraform.tfplan
       ;;

--- a/bin/nbb
+++ b/bin/nbb
@@ -70,13 +70,13 @@ provision_vpc() {
       terraform apply -var-file terraform.tfvars
       ;;
     (destroy)
-      # Run bosh director
+      # Run bosh director, delete cf and bosh
       _bastionIP="$(tf_var bastion_ip)"
       _keyPath="$(sed -e "s#^~#${HOME}#" < <(tf_var aws_key_path))"
 
       _cmd="DEBUG=true \${HOME}/provision destroy"
       ssh -t -i "${_keyPath}" centos@"${_bastionIP}" "${_cmd}"
-
+      # Let terraform clean up
       terraform plan -destroy -var-file terraform.tfvars -out terraform.tfplan
       terraform apply terraform.tfplan
       ;;

--- a/scripts/provision-bastion
+++ b/scripts/provision-bastion
@@ -339,6 +339,8 @@ provision_bosh() {
 }
 
 destroy_bosh() {
+  # Delete the two deployments
+  bosh -n delete deployment cf
   "${HOME}/bin/bosh-init delete ${HOME}/deployments/bosh.yml"
 }
 

--- a/scripts/provision-bastion
+++ b/scripts/provision-bastion
@@ -338,6 +338,10 @@ provision_bosh() {
   provision_bosh_director
 }
 
+destroy_bosh() {
+  "${HOME}/bin/bosh-init delete ${HOME}/deployments/bosh.yml"
+}
+
 main() {
 
   {
@@ -370,6 +374,7 @@ main() {
     (base)          provision_base ;;
     (bosh)          provision_bosh ;;
     (cf)            provision_cf   ;;
+    (destroy)       destroy_bosh   ;;
     (all)
       provision_base
       provision_bosh


### PR DESCRIPTION
Still needs to finish being tested, but this deletes the CF deployment and bosh director from AWS, then lets terraform clean up the NAT and Bastion boxes on a `make destroy`
