### PR TITLE
Fix Java Buildpack Issue

### DIFF
--- a/config/aws/cf-tiny.yml
+++ b/config/aws/cf-tiny.yml
@@ -265,6 +265,7 @@ jobs:
   - { name: uaa, release: cf}
   - { name: metron_agent, release: cf }
   - { name: route_registrar, release: cf }
+  - { name: java-buildpack, release: cf}
   - { name: go-buildpack, release: cf}
   - { name: binary-buildpack, release: cf}
   - { name: nodejs-buildpack, release: cf}
@@ -1019,4 +1020,3 @@ properties:
     ssl:
       port: -1
     url: https://uaa.${cf-domain}
-


### PR DESCRIPTION
Ensures the Java buildpack is available via `cf buildpacks` after a full `make all` run. Self-verified, one-line YAML code change.
