### PR TITLE
First pass at upgrading BOSH to use v2.0 manifests

### DIFF
--- a/config/aws/bosh.yml
+++ b/config/aws/bosh.yml
@@ -43,7 +43,6 @@ jobs:
 
   templates:
   - {name: nats, release: bosh}
-  - {name: redis, release: bosh}
   - {name: postgres, release: bosh}
   - {name: blobstore, release: bosh}
   - {name: director, release: bosh}
@@ -64,11 +63,6 @@ jobs:
       address: 127.0.0.1
       user: nats
       password: nat5pa55
-
-    redis:
-      listen_address: 127.0.0.1
-      address: 127.0.0.1
-      password: redi5pa55
 
     postgres: &db
       listen_address: 127.0.0.1

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -9,8 +9,8 @@ variable "aws_region" {
 variable "bosh" {
   type = "map"
   default =  {
-    version = "255.2"
-    sha1 = "b08fefd771b33f209c3b844b5d316429523c78b1"
+    version = "256.2"
+    sha1 = "ff2f4e16e02f66b31c595196052a809100cfd5a8"
     aws_cpi_version = "48"
     aws_cpi_sha1 = "2abfa1bed326238861e247a10674acf4f7ac48b8"
     type = "ruby"


### PR DESCRIPTION
Right now the only upgrade advice is "remove redis from bosh" -- there are probably other steps that need to be taken to get this working, but right now this works with a fresh, deployed install of cloudfoundry.
