### PR TITLE
Add Provider shutdown command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-instance_list
+/instance_list*
 sshkeys/*
 terraform.tfvars
 .ssh/*.pem

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
+instance_list
+sshkeys/*
 terraform.tfvars
+.ssh/*.pem
 .terraform/
+*.md.html
 *.tfplan
 *.tfstate
 *.tfstate.backup
-*.md.html
-.ssh/*.pem
-sshkeys/*

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ deploy: apply
 centos-ami-ids:
 	./bin/nbb centos-ami-ids
 
-shutdown:
-	./bin/nbb provider shutdown
-
 prepare:
 	./bin/nbb prepare
 
@@ -24,6 +21,12 @@ destroy:
 
 clean:
 	./bin/nbb vpc clean
+
+provider-show:
+	./bin/nbb provider show
+
+provider-shutdown:
+	./bin/nbb provider shutdown
 
 provision:
 	./bin/nbb provision all

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ deploy: apply
 centos-ami-ids:
 	./bin/nbb centos-ami-ids
 
+shutdown:
+	./bin/nbb provider shutdown
+
 prepare:
 	./bin/nbb prepare
 

--- a/bin/nbb
+++ b/bin/nbb
@@ -30,6 +30,18 @@ tf_var() {
   terraform output -state="${STATE_FILE:-${PWD}/terraform.tfstate}" "${1}"
 }
 
+provider() {
+  local _action="${1}"
+  case "${_action}" in
+    (shutdown)
+      shutdown_instances
+      ;;
+    (*)
+      fatal "Unknown provider action '${_action}', expected one of {centos-ami-ids,shutdown}"
+      ;;
+  esac
+}
+
 check_install_terraform()  {
   local _version=0.6.15 _install=false
 
@@ -70,23 +82,6 @@ provision_vpc() {
       terraform apply -var-file terraform.tfvars
       ;;
     (destroy)
-      {
-        _bastionIP="$(tf_var bastion_ip)"
-		if [[ ! -z "${_bastionIP:-}" ]]
-        then
-          # Run bosh director, delete cf and bosh
-	      _keyPath="$(sed -e "s#^~#${HOME}#" < <(tf_var aws_key_path))"
-
-	      _cmd="DEBUG=true \${HOME}/provision destroy"
-	      echo "Running 'provision destroy' on Bastion host"
-	      echo "ssh -t -i ${_keyPath} centos@${_bastionIP} ${_cmd}"
-	      ssh -t -i "${_keyPath}" centos@"${_bastionIP}" "${_cmd}"
-	    fi
-      } || {
-	    echo "Could not connect to destroy BOSH releases and Director"
-	  }
-
-      # Let terraform clean up
       terraform plan -destroy -var-file terraform.tfvars -out terraform.tfplan
       terraform apply terraform.tfplan
       ;;
@@ -316,7 +311,7 @@ provision() {
 
   prepare_cf_tiny_yaml_manifest
   scp_file "/tmp/cf-${_size}.yml" "deployments/cf-${_size}.yml"
-  
+
 	_cmd="DEBUG=true \${HOME}/provision ${_action}"
   ssh -t -i "${_keyPath}" centos@"${_bastionIP}" "${_cmd}"
 }
@@ -344,6 +339,24 @@ find_centos_7_ami_ids() {
   done
 }
 
+shutdown_instances() {
+  aws ec2 describe-instances --filters "Name=instance-state-name,Values=running" | jq -c -r '.Reservations[] .Instances[] .InstanceId' > instance_list
+  echo "You are about to terminate the following instances:"
+  cat instance_list
+  read -r -p "Are you sure? [y/N] " response
+  if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]
+  then
+    IFS=$'\n'  # make newlines the separator
+    for i in `cat ./instance_list`; do
+      echo "Shutting down $i"
+      aws ec2 terminate-instances --instance-ids $i
+    done
+  else
+    echo "Nothing shutdown, exiting..."
+  fi
+  unset IFS
+}
+
 main() {
   [[ -z "${DEBUG:-}" ]] || set -x
 
@@ -361,6 +374,9 @@ main() {
       ;;
     (bastion)
       bastion "$@"
+      ;;
+    (provider)
+      provider "$@"
       ;;
     (centos-ami-ids)
       find_centos_7_ami_ids "$@"

--- a/bin/nbb
+++ b/bin/nbb
@@ -33,11 +33,14 @@ tf_var() {
 provider() {
   local _action="${1}"
   case "${_action}" in
+    (show)
+      show_instances
+      ;;
     (shutdown)
       shutdown_instances
       ;;
     (*)
-      fatal "Unknown provider action '${_action}', expected one of {centos-ami-ids,shutdown}"
+      fatal "Unknown provider action '${_action}', expected one of {centos-ami-ids,show,shutdown}"
       ;;
   esac
 }
@@ -339,10 +342,18 @@ find_centos_7_ami_ids() {
   done
 }
 
+show_instances() {
+  if [[ $# -eq 0 ]]; then
+    aws ec2 describe-tags | jq -r -c '.Tags[] | select (.Key | contains("Name")) | select (.ResourceType | contains("instance")) '
+  else
+    aws ec2 describe-tags | jq -r '.Tags[] | select (.Key | contains("Name")) | select (.ResourceType | contains("instance"))  | .ResourceId ' > ${1}
+  fi
+}
+
 shutdown_instances() {
-  aws ec2 describe-instances --filters "Name=tag:Name,Values=bastion,nat,bosh/0" | jq -c -r '.Reservations[] .Instances[] .InstanceId' > instance_list
-  echo "You are about to terminate the following instances:"
+  show_instances instance_list
   cat instance_list
+  echo "You are about to terminate the above the instances."
   read -r -p "Are you sure? [y/N] " response
   if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]
   then

--- a/bin/nbb
+++ b/bin/nbb
@@ -340,7 +340,7 @@ find_centos_7_ami_ids() {
 }
 
 shutdown_instances() {
-  aws ec2 describe-instances --filters "Name=instance-state-name,Values=running" | jq -c -r '.Reservations[] .Instances[] .InstanceId' > instance_list
+  aws ec2 describe-instances --filters "Name=tag:Name,Values=bastion,nat,bosh/0" | jq -c -r '.Reservations[] .Instances[] .InstanceId' > instance_list
   echo "You are about to terminate the following instances:"
   cat instance_list
   read -r -p "Are you sure? [y/N] " response

--- a/scripts/provision-bastion
+++ b/scripts/provision-bastion
@@ -9,8 +9,8 @@ fatal() { error "$*" ; exit 1 ; }
 provision_path() {
   echo "[provision] Configuring PATH..."
   {
-    if ! [[ -d "${HOME}/bin" ]] 
-    then 
+    if ! [[ -d "${HOME}/bin" ]]
+    then
       mkdir "${HOME}/bin"
       echo 'PATH="$PATH:$HOME/bin"' >> "${HOME}/.bashrc"
     fi
@@ -29,7 +29,7 @@ provision_ssh_keys() {
     then
       touch "${HOME}/.ssh/authorized_keys"
       chmod 0640 "${HOME}/.ssh/authorized_keys"
-      for file in "${HOME}/sshkeys"/* 
+      for file in "${HOME}/sshkeys"/*
       do cat "${file}" >> "${HOME}/.ssh/known_hosts"
       done
       chmod 0600 "${HOME}/.ssh/bosh.pem"
@@ -68,8 +68,8 @@ provision_os_packages() {
 provision_rvm() {
   echo "[provision] Installing RVM..."
   {
-    if [[ ! -d "$HOME/.rvm" ]] 
-    then 
+    if [[ ! -d "$HOME/.rvm" ]]
+    then
       gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
       # curl -sO https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer
       # curl -sO https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer.asc
@@ -101,7 +101,7 @@ provision_bosh_cli() {
     gem install fog-aws -v 0.1.1 --quiet
     gem install bundler bosh_cli --quiet
     bosh -v
-    cat > "${HOME}/.fog" <<EOF 
+    cat > "${HOME}/.fog" <<EOF
     :default:
     :aws_access_key_id: ${awsKeyID}
     :aws_secret_access_key: ${awsAccessKey}
@@ -319,9 +319,9 @@ provision_cf_release() {
   echo "[provision] CF Release..."
   {
     bosh upload release --skip-if-exists "https://bosh.io/d/github.com/cloudfoundry/cf-release?v=${cfReleaseVersion}"
-	
+
 	bosh upload stemcell --skip-if-exists "https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=${cfBOSHUbuntuStemCell}"
-	
+
     bosh deployment "${HOME}/workspace/deployments/cf-${cfSize}.yml"
     for attempt in {0..2}
     do
@@ -449,14 +449,6 @@ provision_bosh() {
   provision_bosh_director
 }
 
-destroy_bosh() {
-  # Delete the two deployments
-  {
-    bosh -n delete deployment cf
-    ${HOME}/bin/bosh-init delete "${HOME}/deployments/bosh.yml"
-  } &>>"${HOME}/provision.log"
-}
-
 install_cf_cli () {
   echo "[provision] Installing Cloud Foundry CLI..."
   {
@@ -500,7 +492,6 @@ main() {
     (base)          provision_base ;;
     (bosh)          provision_bosh ;;
     (cf)            provision_cf   ;;
-    (destroy)       destroy_bosh   ;;
     (cf_cli)        install_cf_cli ;;
     (all)
       provision_base
@@ -519,7 +510,7 @@ main() {
 action="${1}"
 shift || fail "action required as first argument."
 
-# Note that the values of the variables below are filled in before this 
+# Note that the values of the variables below are filled in before this
 # template file is rendered and placed on the bastion server.
 awsKeyID=""
 awsAccessKey=""


### PR DESCRIPTION
This adds the command which paves the way for a `provider` encapsulation we can re-use.

Essentially we want to make a command that is convenient and safe to terminate the servers currently running on EC2.

This is a first cut, we can add layers of control to it.  The "meat" of the search is:

```
aws ec2 describe-instances --filters "Name=instance-state-name,Values=running" | jq -c -r '.Reservations[] .Instances[] .InstanceId' > instance_list
```
